### PR TITLE
Fix subnet route table count

### DIFF
--- a/cluster/vpc.tf
+++ b/cluster/vpc.tf
@@ -59,7 +59,7 @@ resource "aws_route_table" "demo" {
 }
 
 resource "aws_route_table_association" "demo" {
-  count = 2
+  count = local.azCount
 
   subnet_id      = aws_subnet.demo[count.index].id
   route_table_id = aws_route_table.demo.id


### PR DESCRIPTION
The count on the `route_table_association` resource is fixed at 2, but it should match the count of AZs in use. As-is, the result is only two of the created subnets have the route to the Internet Gateway, so if your EKS node winds up in one of the other subnets, it's not able to join the cluster.